### PR TITLE
[mce] Add mouse availability state D-Bus constants. JB#55866

### DIFF
--- a/include/mce/dbus-names.h
+++ b/include/mce/dbus-names.h
@@ -1155,6 +1155,44 @@
 
 /////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
+/** @name Hardware Mouse Availability
+ *
+ *@{
+ */
+
+/** Query HW mouse availability
+ *
+ * @since mce 1.109.0
+ *
+ * Mouse present
+ *
+ * Used for example in evaluating whether mouse pointer
+ * should be shown or not.
+ *
+ * @return string: availability state, one of:
+ * - #MCE_HARDWARE_MOUSE_UNDEF
+ * - #MCE_HARDWARE_MOUSE_AVAILABLE
+ * - #MCE_HARDWARE_MOUSE_NOT_AVAILABLE
+ */
+# define MCE_HARDWARE_MOUSE_STATE_GET      "mouse_available_state_req"
+
+/** Notify changes in HW mouse availability
+ *
+ * @since mce 1.109.0
+ *
+ * Mouse present
+ *
+ * @return string: availability state, one of:
+ * - #MCE_HARDWARE_MOUSE_UNDEF
+ * - #MCE_HARDWARE_MOUSE_AVAILABLE
+ * - #MCE_HARDWARE_MOUSE_NOT_AVAILABLE
+ */
+# define MCE_HARDWARE_MOUSE_STATE_SIG      "mouse_available_state_ind"
+
+/*@}*/
+
+/////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////
 /** @name Sliding Keyboard State
  *
  *@{

--- a/include/mce/mode-names.h
+++ b/include/mce/mode-names.h
@@ -636,6 +636,32 @@
 
 /////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
+/** @name Hardware Mouse Availability Constants
+ *
+ *@{
+ */
+
+/** Hardware Mouse availability is not known
+ *
+ * @since mce 1.109.0
+ */
+# define MCE_HARDWARE_MOUSE_UNDEF                "undef"
+
+/** Hardware Mouse is available
+ *
+ * @since mce 1.109.0
+ */
+# define MCE_HARDWARE_MOUSE_AVAILABLE            "available"
+
+/** Hardware Mouse is not available
+ *
+ * @since mce 1.109.0
+ */
+# define MCE_HARDWARE_MOUSE_NOT_AVAILABLE        "not-available"
+/*@}*/
+
+/////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////
 /** @name Feedback Event Name Constants
  *
  *@{


### PR DESCRIPTION
Constants related to exposing mouse availablity state on D-Bus.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jollamobile.com>